### PR TITLE
RevisionBehaviour.revertToDate: Check if an associated model has a shadow before trying to use it

### DIFF
--- a/models/behaviors/revision.php
+++ b/models/behaviors/revision.php
@@ -521,7 +521,7 @@ class RevisionBehavior extends ModelBehavior {
 			foreach ($associated as $assoc => $data) {
 				
 				/* Continue with next association if no shadow model */
-				if (empty($Model->ShadowModel)) {
+				if (empty($Model->$assoc->ShadowModel)) {
 					continue;
 				}
 				

--- a/models/behaviors/revision.php
+++ b/models/behaviors/revision.php
@@ -519,6 +519,12 @@ class RevisionBehavior extends ModelBehavior {
 		if ($cascade) {		
 			$associated = array_merge($Model->hasMany, $Model->hasOne);
 			foreach ($associated as $assoc => $data) {
+				
+				/* Continue with next association if no shadow model */
+				if (empty($Model->ShadowModel)) {
+					continue;
+				}
+				
 				$ids = array();
 				
 				$cascade = false;


### PR DESCRIPTION
Hi,
There's a problem with the revertToDate function: it fails when a revisioned model is associated with models that are not. Checking if the associated model has a ShadowModel before trying to use it fixes the problem.

I've been using the revision behaviour for a long time--solid work!--but yesterday was the first time I had to use the revertToDate function since someone accidentally deleted important data.

Regards,
Joni
